### PR TITLE
Fix front matter parser for CRLF

### DIFF
--- a/src/__tests__/parseFrontMatter.test.ts
+++ b/src/__tests__/parseFrontMatter.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { extractRuleMeta } from '../utils/registry-manager';
+
+describe('parseFrontMatter compatibility', () => {
+  const tmpDir = path.join(process.cwd(), 'tmp-test');
+  const rulePath = path.join(tmpDir, 'rule.md');
+
+  beforeAll(async () => {
+    await fs.ensureDir(tmpDir);
+    const content = [
+      '---\r',
+      'description: Windows line endings',
+      'globs: **/*.ts',
+      'alwaysApply: true',
+      '---',
+      '',
+      'Rule body'
+    ].join('\r\n');
+    await fs.writeFile(rulePath, content);
+  });
+
+  afterAll(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('handles CRLF front matter', async () => {
+    const meta = await extractRuleMeta(rulePath);
+    expect(meta.description).toBe('Windows line endings');
+    expect(meta.globs).toEqual(['**/*.ts']);
+    expect(meta.alwaysApply).toBe(true);
+  });
+});

--- a/src/utils/registry-manager.ts
+++ b/src/utils/registry-manager.ts
@@ -34,7 +34,8 @@ interface ParsedFrontMatter {
 }
 
 function parseFrontMatter(content: string): ParsedFrontMatter {
-  const FRONT_MATTER_REGEX = /^---\n([\s\S]*?)\n---/;
+  // Support both Unix and Windows line endings
+  const FRONT_MATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
   const match = content.match(FRONT_MATTER_REGEX);
   if (!match) return {};
 


### PR DESCRIPTION
## Summary
- handle Windows line endings in registry manager front‑matter parser
- test CRLF rule metadata parsing

## Testing
- `npm test` *(fails: jest not found)*